### PR TITLE
Don't force text to be black, only toggle bold.

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -37,7 +37,7 @@ function red {
 }
 
 function bold {
-  echo -e "\033[1;30m${@}\033[0m"
+  echo -e "\033[1m${@}\033[0m"
 }
 
 echo -e "\n\n"


### PR DESCRIPTION
The `bold` function forced text to be black, which didn't look good on certain inverted color schemes. Just forcing text to be bold should be more compatible.

**Before**
![screen shot 2013-12-20 at 12 23 19](https://f.cloud.github.com/assets/1167977/1790040/490601c4-696a-11e3-9386-3cee538a2eff.png)

**After**
![screen shot 2013-12-20 at 12 32 44](https://f.cloud.github.com/assets/1167977/1790049/756d3dfe-696a-11e3-91b2-3ce2a40d993f.png)
