### PR TITLE
Added support for aria2

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -64,7 +64,7 @@ function _aria2c {
 
 function download {
   # if there is aria2, use it!
-  if [ -n "`which aria2c`" ]; then
+  if [ -n "$(which aria2c)" ]; then
     _aria2c ${1} ${2}
   else
     _wget ${1}


### PR DESCRIPTION
Hi, I've added the support for aria2 [1] downloader. It's far better than wget, in this case it allows the chuncked download. 
With this patch you can download each episode using 16 parallel connections and _usually_ speed up the download. 

If aria2 is not installed the script will use wget as usual.
If a download is interrupted, aria2 can resume if there is the `episode.aria2` file. The script is configured to not overwrite the existing file, so if the file is present and the aria2 file not, the download will be skipped.

Tested under Ubuntu 14.04 with and without aria2 installed.

[1] http://aria2.sourceforge.net/
